### PR TITLE
Check and skip vendor channels

### DIFF
--- a/errata-import.pl
+++ b/errata-import.pl
@@ -362,6 +362,12 @@ foreach my $channel (sort(@$channellist)) {
     }
   }
 
+  # Check if channel is a vendor channel
+  if ($channel->{'provider_name'} eq 'SUSE') {
+    &info("Excluding vendor channel $channel->{'name'} ($channel->{'label'})\n");
+    next;
+  }
+
   # Sync channels to repo before scanning
   if ($syncchannels) {
     &debug("Getting channel.software.get_details for $channel->{'label'}\n");


### PR DESCRIPTION
In Uyuni, vendor channels are not editable, thus errata cannot presently be added.

This patch checks and skips vendor channels.