### PR TITLE
Revert "Add check to exclude vendor channels"

### DIFF
--- a/errata-import.pl
+++ b/errata-import.pl
@@ -370,12 +370,6 @@ foreach my $channel (sort(@$channellist)) {
     }
   }
 
-  # Check if channel is a vendor channel
-  if ($channel->{'provider_name'} eq 'SUSE') {
-    &info("Excluding vendor channel $channel->{'name'} ($channel->{'label'})\n");
-    next;
-  }
-
   # Sync channels to repo before scanning
   if ($syncchannels) {
     &debug("Getting channel.software.get_details for $channel->{'label'}\n");


### PR DESCRIPTION
With https://github.com/uyuni-project/uyuni/pull/2467 it will be possible to add errata to vendor channels via a new configuration option thus making this check obsolete.